### PR TITLE
Grab bag of minor bugfixes

### DIFF
--- a/db/pg.go
+++ b/db/pg.go
@@ -383,6 +383,9 @@ func (p *PG) ListRunsForPackage(ctx context.Context, pkg string, limit int) ([]*
 }
 
 func (p *PG) ListRunSummariesForRange(ctx context.Context, begin, end time.Time, window time.Duration) ([]*tester.RunSummary, error) {
+	begin = begin.UTC()
+	end = end.UTC()
+
 	buckets := int(math.Ceil(float64(end.Sub(begin)) / float64(window)))
 	summaries := make([]*tester.RunSummary, buckets)
 	for i := 0; i < buckets; i++ {
@@ -427,6 +430,7 @@ func (p *PG) ListRunSummariesForRange(ctx context.Context, begin, end time.Time,
 			if err != nil {
 				return err
 			}
+			runStartedAt = runStartedAt.UTC()
 
 			bucketIndex := int(runStartedAt.Sub(begin) / window)
 			summary := summaries[bucketIndex]

--- a/db/pg.go
+++ b/db/pg.go
@@ -399,8 +399,8 @@ func (p *PG) ListRunSummariesForRange(ctx context.Context, begin, end time.Time,
 			Join("runs ON tests.run_id = runs.id").
 			Where("runs.started_at IS NOT NULL").
 			Where("runs.started_at >= ?", begin).
+			Where("runs.started_at <= ?", end).
 			Where("runs.finished_at IS NOT NULL").
-			Where("runs.finished_at <= ?", end).
 			OrderBy("runs.started_at ASC")
 
 		query, args, err := q.ToSql()

--- a/db/pg_test.go
+++ b/db/pg_test.go
@@ -227,7 +227,7 @@ func TestPG_ListRunSummariesForRange(t *testing.T) {
 
 	t.Run("creates empty buckets", func(t *testing.T) {
 		withPG(t, func(tb testing.TB, pg *PG) {
-			now := time.Now()
+			now := time.Now().UTC()
 			summaries, err := pg.ListRunSummariesForRange(ctx, now, now.Add(3*time.Minute+15*time.Second), time.Minute)
 			require.NoError(t, err)
 			assert.Len(t, summaries, 4)
@@ -240,8 +240,8 @@ func TestPG_ListRunSummariesForRange(t *testing.T) {
 
 	t.Run("places runs in correct buckets", func(t *testing.T) {
 		withPG(t, func(tb testing.TB, pg *PG) {
-			begin := time.Now()
-			end := begin.Add(3 * time.Minute)
+			begin := time.Now().UTC()
+			end := begin.Add(3 * time.Minute).UTC()
 			window := time.Minute
 
 			pkg1run1 := &tester.Run{

--- a/http/templates/dashboard.html
+++ b/http/templates/dashboard.html
@@ -11,7 +11,7 @@
                data-trigger="hover"
                data-placement="bottom"
                data-html="true"
-               data-title="<small>{{.Time | formatTime}} <small>(1h)</small></small>"
+               data-title="<small>{{.Time | formatTime}} <small>(12h)</small></small>"
                data-content="
                              <div>
                                <div class='row'>

--- a/http/ui.go
+++ b/http/ui.go
@@ -289,13 +289,16 @@ func (h *UIHandler) getRunSummary(w http.ResponseWriter, r *http.Request) {
 		h.RenderError(w, r, err, http.StatusBadRequest)
 		return
 	}
+	beginTime := time.Unix(int64(begin), 0)
+
 	window, err := strconv.ParseFloat(r.URL.Query().Get("window"), 64)
 	if err != nil {
 		h.RenderError(w, r, err, http.StatusBadRequest)
 		return
 	}
+	windowDuration := time.Duration(window) * time.Second
 
-	summaries, err := h.db.ListRunSummariesForRange(ctx, time.Unix(int64(begin), 0), time.Unix(int64(begin)+int64(window), 0), time.Duration(window)*time.Second)
+	summaries, err := h.db.ListRunSummariesForRange(ctx, beginTime, beginTime.Add(windowDuration), windowDuration)
 	if err != nil {
 		h.RenderError(w, r, err, http.StatusInternalServerError)
 		return

--- a/scheduler/scheduler.go
+++ b/scheduler/scheduler.go
@@ -240,6 +240,9 @@ func (s *Scheduler) resetStaleRuns(ctx context.Context) error {
 		if time.Now().Sub(run.StartedAt) > s.runTimeout {
 			err = s.db.ResetRun(ctx, run.ID)
 			if err != nil {
+				if err == db.ErrNotFound {
+					continue
+				}
 				return err
 			}
 			log.Printf("reset run %s", run.Package)


### PR DESCRIPTION
- use UTC time consistently
- fix run summaries incorrectly excluding runs in some cases
- fix incorrect time window being shown for overall status
- fix race condition when resetting stale runs