### PR TITLE
Properly escape html output

### DIFF
--- a/http/templates.go
+++ b/http/templates.go
@@ -151,15 +151,11 @@ func (s *UIHandler) templateFuncs() template.FuncMap {
 		"formatPercent": func(f float64) float64 {
 			return f * 100
 		},
-		"formatLogs": func(logData []tester.TBLog) template.HTML {
-			var b strings.Builder
-			for _, l := range logData {
-				b.WriteString(`<span class="text-muted">`)
-				b.WriteString(l.Time.Format("15:04:05"))
-				b.WriteString("</span> ")
-				b.Write(l.Output)
-			}
-			return template.HTML(b.String())
+		"formatLogTime": func(t time.Time) string {
+			return t.Format("15:04:05")
+		},
+		"formatLogOutput": func(o []byte) string {
+			return string(o)
 		},
 		"testStateMessage": func(state tester.TBState) string {
 			return string(state)

--- a/http/templates/run_details.html
+++ b/http/templates/run_details.html
@@ -51,11 +51,7 @@
       {{template "test_card" .}}
     </div>
     <div class="col-lg-8">
-      {{if .Logs}}
-      <pre><code>{{.Logs | formatLogs}}</code></pre>
-      {{else}}
-      <p>No logs received yet...</p>
-      {{end}}
+      {{ template "test_logs" . }}
     </div>
   </div>
   {{end}}

--- a/http/templates/shared/test_logs.html
+++ b/http/templates/shared/test_logs.html
@@ -1,0 +1,11 @@
+{{ define "test_logs" }}
+  {{ if .Logs }}
+    <pre><code>
+      {{- range .Logs -}}
+        <span class="text-muted">{{.Time | formatLogTime}}</span> <span>{{ .Output | formatLogOutput }}</span>
+      {{- end -}}
+    </code></pre>
+  {{ else }}
+    <p>No logs received yet...</p>
+  {{ end }}
+{{ end }}

--- a/http/templates/test_details.html
+++ b/http/templates/test_details.html
@@ -10,10 +10,6 @@
     {{template "test_card" .Test}}
   </div>
   <div class="col-lg-8">
-    {{if .Test.Logs}}
-    <pre><code>{{.Test.Logs | formatLogs}}</code></pre>
-    {{else}}
-    <p>No logs received yet...</p>
-    {{end}}
+    {{ template "test_logs" .Test }}
   </div>
 </div>


### PR DESCRIPTION
Also pulls the log component into a shared partial.