### PR TITLE
Improved packages UI views

### DIFF
--- a/cmd/tester/serve.go
+++ b/cmd/tester/serve.go
@@ -166,7 +166,7 @@ var serveCmd = &cobra.Command{
 		})
 		eg.Go(func() error {
 			for {
-				if err := uiHandler.RefreshSummaries(ctx); err != nil {
+				if _, _, _, _, err := uiHandler.LoadSummaries(ctx); err != nil {
 					log.Printf("failed to refresh summaries %s", err)
 				}
 
@@ -179,7 +179,7 @@ var serveCmd = &cobra.Command{
 		})
 		eg.Go(func() error {
 			log.Print("starting scheduler")
-			scheduler.Run()
+			// scheduler.Run()
 			return nil
 		})
 		err = eg.Wait()

--- a/db/db.go
+++ b/db/db.go
@@ -20,6 +20,7 @@ type DB interface {
 	GetTest(ctx context.Context, id uuid.UUID) (*tester.Test, error)
 	ListTests(ctx context.Context, limit int) ([]*tester.Test, error)
 	ListTestsForPackage(ctx context.Context, pkg string, limit int) ([]*tester.Test, error)
+	ListTestsForPackageInRange(ctx context.Context, pkg string, begin, end time.Time) ([]*tester.Test, error)
 
 	EnqueueRun(ctx context.Context, run *tester.Run) error
 	StartRun(ctx context.Context, id uuid.UUID) error
@@ -31,5 +32,5 @@ type DB interface {
 	ListPendingRuns(ctx context.Context) ([]*tester.Run, error)
 	ListFinishedRuns(ctx context.Context, limit int) ([]*tester.Run, error)
 	ListRunsForPackage(ctx context.Context, pkg string, limit int) ([]*tester.Run, error)
-	ListRunSummariesForRange(ctx context.Context, begin, end time.Time, window time.Duration) ([]*tester.RunSummary, error)
+	ListRunSummariesInRange(ctx context.Context, begin, end time.Time, window time.Duration) ([]*tester.RunSummary, error)
 }

--- a/db/pg.go
+++ b/db/pg.go
@@ -162,6 +162,14 @@ func (p *PG) ListTestsInDateRange(ctx context.Context, from, to time.Time) ([]*t
 	return p.listTests(ctx, p.pool, nil, 0)
 }
 
+func (p *PG) ListTestsForPackageInRange(ctx context.Context, pkg string, from, to time.Time) ([]*tester.Test, error) {
+	return p.listTests(ctx, p.pool, sq.And{
+		sq.Eq{"package": pkg},
+		sq.Expr("result->'started_at' >= ?", from),
+		sq.Expr("result->'started_at' <= ?", to),
+	}, 0)
+}
+
 func (p *PG) EnqueueRun(ctx context.Context, run *tester.Run) error {
 	r := (*pgRun)(run)
 	q := psq.Insert("runs").
@@ -389,7 +397,7 @@ func (p *PG) ListRunsForPackage(ctx context.Context, pkg string, limit int) ([]*
 	return runs, nil
 }
 
-func (p *PG) ListRunSummariesForRange(ctx context.Context, begin, end time.Time, window time.Duration) ([]*tester.RunSummary, error) {
+func (p *PG) ListRunSummariesInRange(ctx context.Context, begin, end time.Time, window time.Duration) ([]*tester.RunSummary, error) {
 	begin = begin.UTC()
 	end = end.UTC()
 

--- a/db/pg_test.go
+++ b/db/pg_test.go
@@ -130,6 +130,14 @@ func TestPG_Test(t *testing.T) {
 				cmp.Equal([]*tester.Test{test2}, listPkgTests),
 				"expected to be equal", cmp.Diff([]*tester.Test{test2}, listPkgTests),
 			)
+
+			listPkgTestsInRange, err := pg.ListTestsForPackageInRange(ctx, "pkg-2", testTime, testTime)
+			require.NoError(t, err)
+			assert.True(
+				t,
+				cmp.Equal([]*tester.Test{test2}, listPkgTestsInRange),
+				"expected to be equal", cmp.Diff([]*tester.Test{test2}, listPkgTestsInRange),
+			)
 		})
 	})
 }
@@ -240,13 +248,13 @@ func TestPG_Run(t *testing.T) {
 	})
 }
 
-func TestPG_ListRunSummariesForRange(t *testing.T) {
+func TestPG_ListRunSummariesInRange(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("creates empty buckets", func(t *testing.T) {
 		withPG(t, func(tb testing.TB, pg *PG) {
 			now := time.Now().UTC()
-			summaries, err := pg.ListRunSummariesForRange(ctx, now, now.Add(3*time.Minute+15*time.Second), time.Minute)
+			summaries, err := pg.ListRunSummariesInRange(ctx, now, now.Add(3*time.Minute+15*time.Second), time.Minute)
 			require.NoError(t, err)
 			assert.Len(t, summaries, 4)
 			for i, summary := range summaries {
@@ -413,7 +421,7 @@ func TestPG_ListRunSummariesForRange(t *testing.T) {
 				require.NoError(t, err)
 			}
 
-			summaries, err := pg.ListRunSummariesForRange(ctx, begin, end, window)
+			summaries, err := pg.ListRunSummariesInRange(ctx, begin, end, window)
 			require.NoError(t, err)
 			assert.Len(t, summaries, 3)
 			assert.Equal(t, &tester.RunSummary{

--- a/http/templates.go
+++ b/http/templates.go
@@ -129,6 +129,9 @@ func (s *UIHandler) templateFuncs() template.FuncMap {
 		"formatTime": func(t time.Time) string {
 			return t.Format("2006-01-02 15:04:05")
 		},
+		"formatTimeRFC3339": func(t time.Time) string {
+			return t.Format(time.RFC3339)
+		},
 		"formatRelativeTime": func(t time.Time) string {
 			d := time.Now().Sub(t)
 			var suffix string

--- a/http/templates/dashboard.html
+++ b/http/templates/dashboard.html
@@ -3,54 +3,7 @@
 
   <div class="row">
     <div class="col">
-      <div class="border p-1">
-        <div class="d-flex">
-          {{range .MonthSummaries}}
-          <div class="flex-grow-1" style="margin: 1px; min-width: 2px; min-height: 80px; max-height: 80px;"
-               data-toggle="popover"
-               data-trigger="hover"
-               data-placement="bottom"
-               data-html="true"
-               data-title="<small>{{.Time | formatTime}} <small>(12h)</small></small>"
-               data-content="
-                             <div>
-                               <div class='row'>
-                                 <div class='col'><strong>Runs</strong></div>
-                               </div>
-                               <div class='row'>
-                                 <div class='col'>Total: {{.NumRuns}} {{if .NumErrorRuns}}<small>({{.NumErrorRuns}} erred)</small>{{end}}</div>
-                               </div>
-                               <hr>
-                               <div class='row'>
-                                 <div class='col'><strong>Tests</strong></div>
-                               </div>
-                               <div class='row'>
-                                 <div class='col-5'>Passed</div>
-                                 <div class='col-7'>{{.NumPassedTests}} <small>({{.PercentPassedTests | formatPercent | printf "%0.1f"}}%)</small></div>
-                               </div>
-                               <div class='row'>
-                                 <div class='col-5'>Skipped</div>
-                                 <div class='col-7'>{{.NumSkippedTests}} <small>({{.PercentSkippedTests | formatPercent | printf "%0.1f"}}%)</small></div>
-                               </div>
-                               <div class='row'>
-                                 <div class='col-5'>Failed</div>
-                                 <div class='col-7'>{{.NumFailedTests}} <small>({{.PercentFailedTests | formatPercent | printf "%0.1f"}}%)</small></div>
-                               </div>
-                             </div>"
-          >
-            <a href="/run_summary?begin={{.Time.Unix}}&window={{.Duration.Seconds}}">
-              <div class="bg-danger bg-gradient" style="min-height: {{.PercentFailedTests | formatPercent}}%;"></div>
-              <div class="bg-warning bg-gradient" style="min-height: {{.PercentSkippedTests | formatPercent}}%;"></div>
-              <div class="bg-success bg-gradient" style="min-height: {{.PercentPassedTests | formatPercent}}%;"></div>
-            </a>
-          </div>
-          {{end}}
-        </div>
-        <div class="d-flex justify-content-between">
-          <div><small class="text-muted">30d <span style="font-size: 60%;">(every 12h)</span></small></div>
-          <div><small class="text-muted">now</small></div>
-        </div>
-      </div>
+      {{ template "run_summary_month" .OverallMonthlyRunSummary }}
     </div>
   </div>
 </div>
@@ -60,116 +13,10 @@
 <div class="packages">
   <h1 class="h3">Results by Package  <small class="text-muted">(last 24h)</small></h1>
   <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3">
-    {{range .Packages}}
-    {{$pkg := .}}
+    {{range .DailyPackageRunSummaries}}
     <div class="col mb-2">
-      <h2 class="h4"><a href="/packages/{{$pkg}}">{{$pkg}}</a></h2>
-
-      <div class="border p-1">
-        <div class="d-flex">
-          {{range $.DaySummaries}}
-          {{$pkgSummary := index .PackageSummary $pkg}}
-          <div class="flex-grow-1" style="margin: 2px; min-width: 5px; min-height: 40px; max-height: 40px;"
-               {{if $pkgSummary}}
-               data-toggle="popover"
-               data-trigger="hover"
-               data-placement="bottom"
-               data-html="true"
-               data-title="<small>{{.Time | formatTime}} <small>(1h)</small></small>"
-               data-content="
-                             <div>
-                               <div class='row'>
-                                 <div class='col'><strong>Runs</strong></div>
-                               </div>
-                               <div class='row'>
-                                 <div class='col'>Total: {{len $pkgSummary.RunIDs}} {{if len $pkgSummary.ErrorRunIDs}}<small>({{len $pkgSummary.ErrorRunIDs}} erred)</small>{{end}}</div>
-                               </div>
-                               <hr>
-                               <div class='row'>
-                                 <div class='col'><strong>Tests</strong></div>
-                               </div>
-                               <div class='row'>
-                                 <div class='col-5'>Passed</div>
-                                 <div class='col-7'>{{$pkgSummary.NumPassedTests}} <small>({{$pkgSummary.PercentPassedTests | formatPercent | printf "%0.1f"}}%)</small></div>
-                               </div>
-                               <div class='row'>
-                                 <div class='col-5'>Skipped</div>
-                                 <div class='col-7'>{{$pkgSummary.NumSkippedTests}} <small>({{$pkgSummary.PercentSkippedTests | formatPercent | printf "%0.1f"}}%)</small></div>
-                               </div>
-                               <div class='row'>
-                                 <div class='col-5'>Failed</div>
-                                 <div class='col-7'>{{$pkgSummary.NumFailedTests}} <small>({{$pkgSummary.PercentFailedTests | formatPercent | printf "%0.1f"}}%)</small></div>
-                               </div>
-                             </div>"
-               {{end}}
-          >
-            <a href="/run_summary?package={{$pkg}}&begin={{.Time.Unix}}&window={{.Duration.Seconds}}">
-              <div style="min-height: 20px;"></div>
-              {{if not $pkgSummary}}
-              <div class="bg-light" style="min-height: 100%;"></div>
-              {{else}}
-              <div class="bg-danger bg-gradient" style="min-height: {{$pkgSummary.PercentFailedTests | formatPercent}}%;"></div>
-              <div class="bg-warning bg-gradient" style="min-height: {{$pkgSummary.PercentSkippedTests | formatPercent}}%;"></div>
-              <div class="bg-success bg-gradient" style="min-height: {{$pkgSummary.PercentPassedTests | formatPercent}}%;"></div>
-              {{end}}
-            </a>
-          </div>
-          {{end}}
-
-          {{range $.HourSummaries}}
-          {{$pkgSummary := index .PackageSummary $pkg}}
-          <div class="flex-grow-1" style="margin: 2px; min-width: 5px; min-height: 60px;"
-               {{if $pkgSummary}}
-               data-toggle="popover"
-               data-trigger="hover"
-               data-placement="bottom"
-               data-html="true"
-               data-title="<small>{{.Time | formatTime}} <small>(5m)</small></small>"
-               data-content="
-                             <div>
-                               <div class='row'>
-                                 <div class='col'><strong>Runs</strong></div>
-                               </div>
-                               <div class='row'>
-                                 <div class='col'>Total: {{len $pkgSummary.RunIDs}} {{if len $pkgSummary.ErrorRunIDs}}<small>({{len $pkgSummary.ErrorRunIDs}} erred)</small>{{end}}</div>
-                               </div>
-                               <hr>
-                               <div class='row'>
-                                 <div class='col'><strong>Tests</strong></div>
-                               </div>
-                               <div class='row'>
-                                 <div class='col-5'>Passed</div>
-                                 <div class='col-7'>{{$pkgSummary.NumPassedTests}} <small>({{$pkgSummary.PercentPassedTests | formatPercent | printf "%0.1f"}}%)</small></div>
-                               </div>
-                               <div class='row'>
-                                 <div class='col-5'>Skipped</div>
-                                 <div class='col-7'>{{$pkgSummary.NumSkippedTests}} <small>({{$pkgSummary.PercentSkippedTests | formatPercent | printf "%0.1f"}}%)</small></div>
-                               </div>
-                               <div class='row'>
-                                 <div class='col-5'>Failed</div>
-                                 <div class='col-7'>{{$pkgSummary.NumFailedTests}} <small>({{$pkgSummary.PercentFailedTests | formatPercent | printf "%0.1f"}}%)</small></div>
-                               </div>
-                             </div>"
-               {{end}}
-          >
-            <a href="/run_summary?package={{$pkg}}&begin={{.Time.Unix}}&window={{.Duration.Seconds}}">
-              {{if not $pkgSummary}}
-              <div class="bg-light" style="min-height: 100%;"></div>
-              {{else}}
-              <div class="bg-danger bg-gradient" style="min-height: {{$pkgSummary.PercentFailedTests | formatPercent}}%;"></div>
-              <div class="bg-warning bg-gradient" style="min-height: {{$pkgSummary.PercentSkippedTests | formatPercent}}%;"></div>
-              <div class="bg-success bg-gradient" style="min-height: {{$pkgSummary.PercentPassedTests | formatPercent}}%;"></div>
-              {{end}}
-            </a>
-          </div>
-          {{end}}
-        </div>
-        <div class="d-flex">
-          <div style="width: 65%;"><small class="text-muted">24h <span style="font-size: 60%;">(every 1h)</span></small></div>
-          <div class="flex-grow-1"><small class="text-muted">1h <span style="font-size: 60%;">(every 5m)</span></small></div>
-          <div><small class="text-muted">now</small></div>
-        </div>
-      </div>
+      <h2 class="h4"><a href="/packages/{{ .Name }}">{{ .Name }}</a></h2>
+      {{ template "package_run_summary_day" . }}
     </div>
     {{else}}
     <div class="col">

--- a/http/templates/layouts/default.html
+++ b/http/templates/layouts/default.html
@@ -6,6 +6,7 @@
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/5.0.0-alpha2/css/bootstrap.min.css" integrity="sha384-DhY6onE6f3zzKbjUPRc2hOzGAdEf4/Dz+WJwBvEYL/lkkIsI3ihufq9hk9K4lVoK" crossorigin="anonymous">
 
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.bundle.min.js" integrity="sha256-TQq84xX6vkwR0Qs1qH5ADkP+MvH0W+9E7TdHJsoIQiM=" crossorigin="anonymous"></script>
 
     <title>{{block "title" .}}Tester{{end}}</title>
 

--- a/http/templates/layouts/default.html
+++ b/http/templates/layouts/default.html
@@ -4,7 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/5.0.0-alpha1/css/bootstrap.min.css" integrity="sha384-r4NyP46KrjDleawBgD5tp8Y7UzmLA05oM1iAEQ17CSuDqnUK2+k9luXQOfXJCJ4I" crossorigin="anonymous">
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/5.0.0-alpha2/css/bootstrap.min.css" integrity="sha384-DhY6onE6f3zzKbjUPRc2hOzGAdEf4/Dz+WJwBvEYL/lkkIsI3ihufq9hk9K4lVoK" crossorigin="anonymous">
+
 
     <title>{{block "title" .}}Tester{{end}}</title>
 
@@ -46,8 +47,8 @@
       {{template "content" .}}
     </main>
 
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/5.0.0-alpha1/js/bootstrap.min.js" integrity="sha384-oesi62hOLfzrys4LxRF63OJCXdXDipiYWBnvTl9Y9/TRlw5xlKIEHpNyvvDShgf/" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.1/dist/umd/popper.min.js" integrity="sha384-9/reFTGAW83EW2RDu2S0VKaIzap3H66lZH81PoYlFhbGU+6BZp6G7niu735Sk7lN" crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/5.0.0-alpha2/js/bootstrap.bundle.min.js" integrity="sha384-BOsAfwzjNJHrJ8cZidOg56tcQWfp6y72vEJ8xQ9w6Quywb24iOsW913URv1IS4GD" crossorigin="anonymous"></script>
     <script>
       var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-toggle="tooltip"]'))
       var tooltipList = tooltipTriggerList.map(function (tooltipTriggerEl) {

--- a/http/templates/package_details.html
+++ b/http/templates/package_details.html
@@ -1,19 +1,141 @@
 <div class="package-details">
   <div class="row">
     <div class="col">
-      <h2 class="h4"><a href="/packages/{{.Name}}">{{.Name}}</a></h2>
-      {{if .Runs}}
+      <h1>{{.Name}}</h1>
+      <h2>Overall Results <small class="text-muted">(last 30d)</small></h2>
+      {{ template "package_run_summary_month" .MonthlyPackageRunSummary }}
+
+      <hr>
+
+      <h2>Latest Runs <small class="text-muted">(last 5)</small></h2>
+      {{if .LatestRuns}}
       <div class="row row-cols-1 row-cols-md-4 row-cols-lg-5 g-3">
-        {{range .Runs}}
+        {{range .LatestRuns}}
         <div class="col">
           {{template "run_card" .}}
         </div>
         {{end}}
       </div>
       {{else}}
-      <h5>No runs yet</h5>
+      <h3>No runs yet</h3>
       <p>Kick off a test run and publish the results...</p>
       {{end}}
+
+      <hr>
+
+      <h2>Tests</h2>
+      {{ range $name, $tests := .TestsByName }}
+      <h3>{{ $name }}</h3>
+      <div class="row">
+        <div class="col" style="height: 300px;">
+          <canvas id="{{ $name }}-runs"></canvas>
+          <script>
+            var chart = new Chart("{{ $name }}-runs", {
+	      type: 'scatter',
+	      data: {
+		datasets: [
+                  {
+                    label: "passed",
+		    data: [
+                      {{ range $tests }}
+                      {{ if eq .Result.State "passed" }}
+                      {
+                        x: new Date("{{ .Result.StartedAt | formatTimeRFC3339 }}"),
+                        y: {{ .Result.Duration.Seconds }},
+                        id: {{ .ID }},
+                      },
+                      {{ end }}
+                      {{ end }}
+                    ],
+                    backgroundColor: '#198754',
+		  },
+                  {
+                    label: "failed",
+		    data: [
+                      {{ range $tests }}
+                      {{ if eq .Result.State "failed" }}
+                      {
+                        x: new Date("{{ .Result.StartedAt | formatTimeRFC3339 }}"),
+                        y: {{ .Result.Duration.Seconds }},
+                        id: {{ .ID }},
+                      },
+                      {{ end }}
+                      {{ end }}
+                    ],
+                    backgroundColor: '#dc3545',
+                  },
+                  {
+                    label: "skipped",
+		    data: [
+                      {{ range $tests }}
+                      {{ if eq .Result.State "skipped" }}
+                      {
+                        x: new Date("{{ .Result.StartedAt | formatTimeRFC3339 }}"),
+                        y: {{ .Result.Duration.Seconds }},
+                        id: {{ .ID }},
+                      },
+                      {{ end }}
+                      {{ end }}
+                    ],
+                    backgroundColor: '#ffc107',
+                  },
+                ],
+	      },
+	      options: {
+                legend: {
+                  display: false,
+                },
+                tooltips: {
+                  callbacks: {
+                    label: function(tooltipItem, data) {
+                      return data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index].id;
+                    },
+                    label: function(tooltipItem, data) {
+                      var label = 'Duration (s): ';
+                      label += data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index].y;
+                      return label;
+                    },
+                  },
+                },
+                onClick: function(e, el) {
+                  if (el.length === 0) {
+                    return
+                  }
+                  var testID = el[0]._chart.config.data.datasets[el[0]._datasetIndex].data[el[0]._index].id;
+                  location.href = "/tests/" + testID;
+                },
+		scales: {
+		  xAxes: [{
+		    type: 'time',
+                    time: {
+                      distribution: 'linear',
+                      unit: 'day',
+                      displayFormats: {
+                        day: "MMM D, YYYY"
+                      },
+		    },
+		    scaleLabel: {
+		      display: true,
+		      labelString: 'Time'
+		    }
+		  }],
+                  yAxes: [{
+                    scaleLabel: {
+                      display: true,
+                      labelString: 'Duration (s)',
+                    },
+                    ticks: {
+                      precision: 3,
+                    },
+                  }],
+		},
+                maintainAspectRatio: false,
+	      }
+	    });
+          </script>
+        </div>
+      </div>
+      {{ end }}
     </div>
   </div>
 </div>

--- a/http/templates/packages.html
+++ b/http/templates/packages.html
@@ -1,20 +1,9 @@
 <div class="packages">
-  {{range .Packages}}
+  {{ range . }}
   <div class="row mb-2">
     <div class="col">
-      <h2 class="h4"><a href="/packages/{{.Name}}">{{.Name}}</a></h2>
-      {{if .Runs}}
-      <div class="row row-cols-1 row-cols-md-4 row-cols-lg-5 g-3">
-        {{range .Runs}}
-        <div class="col">
-          {{template "run_card" .}}
-        </div>
-        {{end}}
-      </div>
-      {{else}}
-      <h5>No runs yet</h5>
-      <p>Kick off a test run and publish the results...</p>
-      {{end}}
+      <h2 class="h4"><a href="/packages/{{ .Name }}">{{ .Name }}</a></h2>
+      {{ template "package_run_summary_month" . }}
     </div>
   </div>
   {{else}}

--- a/http/templates/shared/package_run_summary_bar.html
+++ b/http/templates/shared/package_run_summary_bar.html
@@ -1,0 +1,5 @@
+{{ define "package_run_summary_bar" }}
+<div class="bg-danger bg-gradient" style="min-height: calc(100% * {{ .PercentFailedTests }});"></div>
+<div class="bg-warning bg-gradient" style="min-height: calc(100% * {{ .PercentSkippedTests }});"></div>
+<div class="bg-success bg-gradient" style="min-height: calc(100% * {{ .PercentPassedTests }});"></div>
+{{ end }}

--- a/http/templates/shared/package_run_summary_day.html
+++ b/http/templates/shared/package_run_summary_day.html
@@ -1,0 +1,56 @@
+{{ define "package_run_summary_day" }}
+<div class="border p-1">
+  <div class="d-flex">
+    {{ range $.DaySummaries }}
+    {{ $pkgSummary := index .PackageSummary $.Name }}
+    <a class="flex-grow-1" style="margin: 1px; min-width: 2px; min-height: {{ $.Height }}px; max-height: {{ $.Height }}px;"
+       href="/run_summary?package={{ $.Name }}&begin={{ .Time.Unix }}&window={{ .Duration.Seconds }}"
+       {{if $pkgSummary}}
+       data-toggle="popover"
+       data-trigger="hover"
+       data-placement="bottom"
+       data-html="true"
+       data-title="<small>{{ .Time | formatTime }} <small>({{ .Duration.String }})</small></small>"
+       data-content="{{ template "package_run_summary_tooltip" $pkgSummary }}"
+       {{end}}
+       >
+      {{if not $pkgSummary}}
+      <div class="bg-light" style="min-height: 100%;"></div>
+      {{else}}
+      <div style="min-height: calc(1 * {{ $.HeightDiff }}px);"></div>
+      <div style="height: calc({{ $.Height }}px - 1 * {{ $.HeightDiff }}px);">
+        {{ template "package_run_summary_bar" $pkgSummary }}
+      </div>
+      {{end}}
+    </a>
+    {{end}}
+
+    {{ range $.HourSummaries }}
+    {{ $pkgSummary := index .PackageSummary $.Name }}
+    <a class="flex-grow-1" style="margin: 1px; min-width: 2px; min-height: {{ $.Height }}px; max-height: {{ $.Height }}px;"
+       href="/run_summary?package={{ $.Name }}&begin={{ .Time.Unix }}&window={{ .Duration.Seconds }}"
+       {{if $pkgSummary}}
+       data-toggle="popover"
+       data-trigger="hover"
+       data-placement="bottom"
+       data-html="true"
+       data-title="<small>{{ .Time | formatTime }} <small>({{ .Duration.String }})</small></small>"
+       data-content="{{ template "package_run_summary_tooltip" $pkgSummary }}"
+       {{end}}
+       >
+      {{if not $pkgSummary}}
+      <div class="bg-light" style="min-height: 100%;"></div>
+      {{else}}
+      {{ template "package_run_summary_bar" $pkgSummary }}
+      {{end}}
+    </a>
+    {{end}}
+  </div>
+  <div class="d-flex justify-content-between">
+    <div style="width: calc(100% * 58 / (58 + 23 + 12));"><small class="text-muted">30d</small></div>
+    <div style="width: calc(100% * 23 / (58 + 23 + 12));"><small class="text-muted">24h</small></div>
+    <div class="flex-grow-1"><small class="text-muted">1h</small></div>
+    <div><small class="text-muted">now</small></div>
+  </div>
+</div>
+{{ end }}

--- a/http/templates/shared/package_run_summary_month.html
+++ b/http/templates/shared/package_run_summary_month.html
@@ -1,0 +1,80 @@
+{{ define "package_run_summary_month" }}
+<div class="border p-1">
+  <div class="d-flex">
+    {{ range .MonthSummaries }}
+    {{ $pkgSummary := index .PackageSummary $.Name }}
+    <a class="flex-grow-1" style="margin: 1px; min-width: 2px; min-height: {{ $.Height }}px; max-height: {{ $.Height }}px;"
+       href="/run_summary?package={{ $.Name }}&begin={{ .Time.Unix }}&window={{ .Duration.Seconds }}"
+       {{if $pkgSummary}}
+       data-toggle="popover"
+       data-trigger="hover"
+       data-placement="bottom"
+       data-html="true"
+       data-title="<small>{{ .Time | formatTime }} <small>({{ .Duration.String }})</small></small>"
+       data-content="{{ template "package_run_summary_tooltip" $pkgSummary }}"
+       {{end}}
+       >
+      {{if not $pkgSummary}}
+      <div class="bg-light" style="min-height: 100%;"></div>
+      {{else}}
+      <div style="min-height: calc(2 * {{ $.HeightDiff }}px);"></div>
+      <div style="height: calc({{ $.Height }}px - 2 * {{ $.HeightDiff }}px);">
+        {{ template "package_run_summary_bar" $pkgSummary }}
+      </div>
+      {{end}}
+    </a>
+    {{end}}
+
+    {{ range $.DaySummaries }}
+    {{ $pkgSummary := index .PackageSummary $.Name }}
+    <a class="flex-grow-1" style="margin: 1px; min-width: 2px; min-height: {{ $.Height }}px; max-height: {{ $.Height }}px;"
+       href="/run_summary?package={{ $.Name }}&begin={{ .Time.Unix }}&window={{ .Duration.Seconds }}"
+       {{if $pkgSummary}}
+       data-toggle="popover"
+       data-trigger="hover"
+       data-placement="bottom"
+       data-html="true"
+       data-title="<small>{{ .Time | formatTime }} <small>({{ .Duration.String }})</small></small>"
+       data-content="{{ template "package_run_summary_tooltip" $pkgSummary }}"
+       {{end}}
+       >
+      {{if not $pkgSummary}}
+      <div class="bg-light" style="min-height: 100%;"></div>
+      {{else}}
+      <div style="min-height: calc(1 * {{ $.HeightDiff }}px);"></div>
+      <div style="height: calc({{ $.Height }}px - 1 * {{ $.HeightDiff }}px);">
+        {{ template "package_run_summary_bar" $pkgSummary }}
+      </div>
+      {{end}}
+    </a>
+    {{end}}
+
+    {{ range $.HourSummaries }}
+    {{ $pkgSummary := index .PackageSummary $.Name }}
+    <a class="flex-grow-1" style="margin: 1px; min-width: 2px; min-height: {{ $.Height }}px; max-height: {{ $.Height }}px;"
+       href="/run_summary?package={{ $.Name }}&begin={{ .Time.Unix }}&window={{ .Duration.Seconds }}"
+       {{if $pkgSummary}}
+       data-toggle="popover"
+       data-trigger="hover"
+       data-placement="bottom"
+       data-html="true"
+       data-title="<small>{{ .Time | formatTime }} <small>({{ .Duration.String }})</small></small>"
+       data-content="{{ template "package_run_summary_tooltip" $pkgSummary }}"
+       {{end}}
+       >
+      {{if not $pkgSummary}}
+      <div class="bg-light" style="min-height: 100%;"></div>
+      {{else}}
+      {{ template "package_run_summary_bar" $pkgSummary }}
+      {{end}}
+    </a>
+    {{end}}
+  </div>
+  <div class="d-flex justify-content-between">
+    <div style="width: calc(100% * 58 / (58 + 23 + 12));"><small class="text-muted">30d</small></div>
+    <div style="width: calc(100% * 23 / (58 + 23 + 12));"><small class="text-muted">24h</small></div>
+    <div class="flex-grow-1"><small class="text-muted">1h</small></div>
+    <div><small class="text-muted">now</small></div>
+  </div>
+</div>
+{{ end }}

--- a/http/templates/shared/package_run_summary_tooltip.html
+++ b/http/templates/shared/package_run_summary_tooltip.html
@@ -1,0 +1,26 @@
+{{ define "package_run_summary_tooltip" }}
+<div>
+  <div class='row'>
+    <div class='col'><strong>Runs</strong></div>
+  </div>
+  <div class='row'>
+    <div class='col'>Total: {{ len .RunIDs }} {{ if len .ErrorRunIDs }}<small>({{ len .ErrorRunIDs }} erred)</small>{{ end }}</div>
+  </div>
+  <hr>
+  <div class='row'>
+    <div class='col'><strong>Tests</strong></div>
+  </div>
+  <div class='row'>
+    <div class='col-5'>Passed</div>
+    <div class='col-7'>{{ .NumPassedTests }} <small>({{ .PercentPassedTests | formatPercent | printf "%0.1f" }}%)</small></div>
+  </div>
+  <div class='row'>
+    <div class='col-5'>Skipped</div>
+    <div class='col-7'>{{ .NumSkippedTests }} <small>({{ .PercentSkippedTests | formatPercent | printf "%0.1f" }}%)</small></div>
+  </div>
+  <div class='row'>
+    <div class='col-5'>Failed</div>
+    <div class='col-7'>{{ .NumFailedTests }} <small>({{ .PercentFailedTests | formatPercent | printf "%0.1f" }}%)</small></div>
+  </div>
+</div>
+{{ end }}

--- a/http/templates/shared/run_summary_month.html
+++ b/http/templates/shared/run_summary_month.html
@@ -1,0 +1,90 @@
+{{ define "run_summary_month_tooltip" }}
+<div>
+  <div class='row'>
+    <div class='col'><strong>Runs</strong></div>
+  </div>
+  <div class='row'>
+    <div class='col'>Total: {{ .NumRuns }} {{ if .NumErrorRuns }}<small>({{ .NumErrorRuns }} erred)</small>{{ end }}</div>
+  </div>
+  <hr>
+  <div class='row'>
+    <div class='col'><strong>Tests</strong></div>
+  </div>
+  <div class='row'>
+    <div class='col-5'>Passed</div>
+    <div class='col-7'>{{ .NumPassedTests }} <small>({{ .PercentPassedTests | formatPercent | printf "%0.1f" }}%)</small></div>
+  </div>
+  <div class='row'>
+    <div class='col-5'>Skipped</div>
+    <div class='col-7'>{{ .NumSkippedTests }} <small>({{ .PercentSkippedTests | formatPercent | printf "%0.1f" }}%)</small></div>
+  </div>
+  <div class='row'>
+    <div class='col-5'>Failed</div>
+    <div class='col-7'>{{ .NumFailedTests }} <small>({{ .PercentFailedTests | formatPercent | printf "%0.1f" }}%)</small></div>
+  </div>
+</div>
+{{ end }}
+{{ define "run_summary_month_bar" }}
+<div class="bg-danger bg-gradient" style="min-height: calc(100% * {{ .PercentFailedTests }});"></div>
+<div class="bg-warning bg-gradient" style="min-height: calc(100% * {{ .PercentSkippedTests }});"></div>
+<div class="bg-success bg-gradient" style="min-height: calc(100% * {{ .PercentPassedTests }});"></div>
+{{ end }}
+{{ define "run_summary_month" }}
+<div class="border p-1">
+  <div class="d-flex">
+    {{range .MonthSummaries}}
+    <a class="flex-grow-1" style="margin: 1px; min-width: 2px; min-height: {{ $.Height }}px; max-height: {{ $.Height }}px;"
+       href="/run_summary?begin={{ .Time.Unix }}&window={{ .Duration.Seconds }}"
+       data-toggle="popover"
+       data-trigger="hover"
+       data-placement="bottom"
+       data-html="true"
+       data-title="<small>{{.Time | formatTime}} <small>(12h)</small></small>"
+       data-content="{{ template "run_summary_month_tooltip" . }}"
+       >
+      <div style="min-height: calc(2 * {{ $.HeightDiff }}px);"></div>
+      <div style="height: calc({{ $.Height }}px - 2 * {{ $.HeightDiff }}px);">
+        {{ template "run_summary_month_bar" . }}
+      </div>
+    </a>
+    {{end}}
+
+    {{range .DaySummaries}}
+    <a class="flex-grow-1" style="margin: 1px; min-width: 2px; min-height: {{ $.Height }}px; max-height: {{ $.Height }}px;"
+       href="/run_summary?begin={{.Time.Unix}}&window={{.Duration.Seconds}}"
+       data-toggle="popover"
+       data-trigger="hover"
+       data-placement="bottom"
+       data-html="true"
+       data-title="<small>{{.Time | formatTime}} <small>(1h)</small></small>"
+       data-content="{{ template "run_summary_month_tooltip" . }}"
+       >
+      <div style="min-height: calc(1 * {{ $.HeightDiff }}px);"></div>
+      <div style="height: calc({{ $.Height }}px - 1 * {{ $.HeightDiff }}px);">
+        {{ template "run_summary_month_bar" . }}
+      </div>
+    </a>
+    {{end}}
+
+    {{range .HourSummaries}}
+    <a class="flex-grow-1" style="margin: 1px; min-width: 2px; min-height: {{ $.Height }}px; max-height: {{ $.Height }}px;"
+       href="/run_summary?begin={{.Time.Unix}}&window={{.Duration.Seconds}}"
+       data-toggle="popover"
+       data-trigger="hover"
+       data-placement="bottom"
+       data-html="true"
+       data-title="<small>{{.Time | formatTime}} <small>(5m)</small></small>"
+       data-content="{{ template "run_summary_month_tooltip" . }}"
+       >
+        {{ template "run_summary_month_bar" . }}
+    </a>
+    {{end}}
+  </div>
+  <div class="d-flex justify-content-between">
+    <div style="width: calc(100% * 58 / (58 + 23 + 12));"><small class="text-muted">30d</small></div>
+    <div style="width: calc(100% * 23 / (58 + 23 + 12));"><small class="text-muted">24h</small></div>
+    <div class="flex-grow-1"><small class="text-muted">1h</small></div>
+    <div><small class="text-muted">now</small></div>
+  </div>
+</div>
+{{ end }}


### PR DESCRIPTION
- adds a similar 30day bar view to list packages
- reworks package details page to include:
  - 30 day bar view
  - last 5 runs
  - breakdown of run success/duration scatter plot