### PR TITLE
Fix incorrect time labeling for 24h package run summaries

### DIFF
--- a/http/templates/shared/package_run_summary_day.html
+++ b/http/templates/shared/package_run_summary_day.html
@@ -47,8 +47,7 @@
     {{end}}
   </div>
   <div class="d-flex justify-content-between">
-    <div style="width: calc(100% * 58 / (58 + 23 + 12));"><small class="text-muted">30d</small></div>
-    <div style="width: calc(100% * 23 / (58 + 23 + 12));"><small class="text-muted">24h</small></div>
+    <div style="width: calc(100% * 23 / (23 + 12));"><small class="text-muted">24h</small></div>
     <div class="flex-grow-1"><small class="text-muted">1h</small></div>
     <div><small class="text-muted">now</small></div>
   </div>


### PR DESCRIPTION
This fixes a regression I introduced with some refactoring of the run summary components.