### PR TITLE
Use the same timescale for package test run graphs

### DIFF
--- a/http/templates/layouts/default.html
+++ b/http/templates/layouts/default.html
@@ -6,7 +6,9 @@
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/5.0.0-alpha2/css/bootstrap.min.css" integrity="sha384-DhY6onE6f3zzKbjUPRc2hOzGAdEf4/Dz+WJwBvEYL/lkkIsI3ihufq9hk9K4lVoK" crossorigin="anonymous">
 
-    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.bundle.min.js" integrity="sha256-TQq84xX6vkwR0Qs1qH5ADkP+MvH0W+9E7TdHJsoIQiM=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/luxon@1.25.0/build/global/luxon.min.js" integrity="sha256-OVk2fwTRcXYlVFxr/ECXsakqelJbOg5WCj1dXSIb+nU=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@3.0.0-beta.4/dist/chart.min.js" integrity="sha256-f3G7brzKP7yZvxb4b3eSpi75AN9bq91NvjpkvzM5ODw=" crossorigin="anonymous"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-luxon@0.2.2/dist/chartjs-adapter-luxon.min.js" integrity="sha256-bgbnCTiuk9rPHmlLrX1soTSIxQJs26agg9kSWIhdcfc=" crossorigin="anonymous"></script>
 
     <title>{{block "title" .}}Tester{{end}}</title>
 

--- a/http/templates/package_details.html
+++ b/http/templates/package_details.html
@@ -37,45 +37,45 @@
                   {
                     label: "passed",
 		    data: [
-                      {{ range $tests }}
-                      {{ if eq .Result.State "passed" }}
+                      {{ range $tests -}}
+                      {{ if eq .Result.State "passed" -}}
                       {
-                        x: new Date("{{ .Result.StartedAt | formatTimeRFC3339 }}"),
-                        y: {{ .Result.Duration.Seconds }},
-                        id: {{ .ID }},
+                        x: luxon.DateTime.fromISO("{{- .Result.StartedAt | formatTimeRFC3339 -}}"),
+                        y: {{- .Result.Duration.Seconds -}},
+                        id: {{- .ID -}},
                       },
-                      {{ end }}
-                      {{ end }}
+                      {{- end }}
+                      {{- end }}
                     ],
                     backgroundColor: '#198754',
 		  },
                   {
                     label: "failed",
 		    data: [
-                      {{ range $tests }}
-                      {{ if eq .Result.State "failed" }}
+                      {{ range $tests -}}
+                      {{ if eq .Result.State "failed" -}}
                       {
-                        x: new Date("{{ .Result.StartedAt | formatTimeRFC3339 }}"),
-                        y: {{ .Result.Duration.Seconds }},
-                        id: {{ .ID }},
+                        x: luxon.DateTime.fromISO("{{- .Result.StartedAt | formatTimeRFC3339 -}}"),
+                        y: {{- .Result.Duration.Seconds -}},
+                        id: {{- .ID -}},
                       },
-                      {{ end }}
-                      {{ end }}
+                      {{- end }}
+                      {{- end }}
                     ],
                     backgroundColor: '#dc3545',
                   },
                   {
                     label: "skipped",
 		    data: [
-                      {{ range $tests }}
-                      {{ if eq .Result.State "skipped" }}
+                      {{ range $tests -}}
+                      {{ if eq .Result.State "skipped" -}}
                       {
-                        x: new Date("{{ .Result.StartedAt | formatTimeRFC3339 }}"),
-                        y: {{ .Result.Duration.Seconds }},
-                        id: {{ .ID }},
+                        x: luxon.DateTime.fromISO("{{- .Result.StartedAt | formatTimeRFC3339 -}}"),
+                        y: {{- .Result.Duration.Seconds -}},
+                        id: {{- .ID -}},
                       },
-                      {{ end }}
-                      {{ end }}
+                      {{- end }}
+                      {{- end }}
                     ],
                     backgroundColor: '#ffc107',
                   },
@@ -87,41 +87,52 @@
                 },
                 tooltips: {
                   callbacks: {
-                    label: function(tooltipItem, data) {
-                      return data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index].id;
+                    title: function(context) {
+                      if (!context || context.length === 0) {
+                        return null;
+                      }
+                      var data = context[0].dataset.data[context[0].dataIndex];
+                      return data.id;
                     },
-                    label: function(tooltipItem, data) {
-                      var label = 'Duration (s): ';
-                      label += data.datasets[tooltipItem.datasetIndex].data[tooltipItem.index].y;
+                    label: function(context) {
+                      var data = context.dataset.data[context.dataIndex];
+                      var label = data.y.toFixed(2);
+                      label += "s @ "
+                      label += data.x.toFormat("DD H:mm:ss");
                       return label;
                     },
                   },
                 },
                 onClick: function(e, el) {
-                  if (el.length === 0) {
+                  if (!el || el.length === 0) {
                     return
                   }
-                  var testID = el[0]._chart.config.data.datasets[el[0]._datasetIndex].data[el[0]._index].id;
+                  var data = e.chart.data.datasets[el[0].datasetIndex].data[el[0].index];
+                  var testID = data.id;
                   location.href = "/tests/" + testID;
                 },
 		scales: {
-		  xAxes: [{
+		  x: {
 		    type: 'time',
+                    adapters: {
+                      date: {
+                        zone: "utc",
+                      },
+                    },
+                    min: "{{- $.LastWeek | formatTimeRFC3339 -}}",
+                    max: "{{- $.Now | formatTimeRFC3339 -}}",
                     time: {
-                      distribution: 'linear',
                       unit: 'day',
                       displayFormats: {
-                        day: "MMM D, YYYY"
+                        day: "DD"
                       },
-                      min: new Date("{{ $.LastWeek | formatTimeRFC3339 }}"),
-                      max: new Date("{{ $.Now | formatTimeRFC3339 }}"),
 		    },
 		    scaleLabel: {
 		      display: true,
 		      labelString: 'Time'
 		    }
-		  }],
-                  yAxes: [{
+		  },
+                  y: {
                     scaleLabel: {
                       display: true,
                       labelString: 'Duration (s)',
@@ -129,7 +140,7 @@
                     ticks: {
                       precision: 3,
                     },
-                  }],
+                  },
 		},
                 maintainAspectRatio: false,
 	      }

--- a/http/templates/package_details.html
+++ b/http/templates/package_details.html
@@ -23,7 +23,7 @@
 
       <hr>
 
-      <h2>Tests</h2>
+      <h2>Tests <small class="text-muted">(last 7d)</small></h2>
       {{ range $name, $tests := .TestsByName }}
       <h3>{{ $name }}</h3>
       <div class="row">
@@ -113,6 +113,8 @@
                       displayFormats: {
                         day: "MMM D, YYYY"
                       },
+                      min: new Date("{{ $.LastWeek | formatTimeRFC3339 }}"),
+                      max: new Date("{{ $.Now | formatTimeRFC3339 }}"),
 		    },
 		    scaleLabel: {
 		      display: true,

--- a/http/ui.go
+++ b/http/ui.go
@@ -241,11 +241,15 @@ func (h *UIHandler) getPackage(w http.ResponseWriter, r *http.Request) {
 		MonthlyPackageRunSummary *monthlyPackageRunSummary
 		LatestRuns               []*tester.Run
 		TestsByName              map[string][]*tester.Test
+		Now                      time.Time
+		LastWeek                 time.Time
 	}{
 		Name:                     pkg,
 		MonthlyPackageRunSummary: monthlyRunSummary,
 		LatestRuns:               latestRuns,
 		TestsByName:              monthlyTestsByName,
+		Now:                      now,
+		LastWeek:                 lastWeek,
 	}
 
 	h.Render(w, r, "package_details", value)

--- a/http/ui.go
+++ b/http/ui.go
@@ -201,8 +201,8 @@ func (h *UIHandler) getPackage(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	now := time.Now()
-	lastWeek := now.Add(-7 * 24 * time.Hour)
+	now := time.Now().UTC()
+	lastWeek := now.Add(-7 * 24 * time.Hour).UTC()
 
 	monthlyTests, err := h.db.ListTestsForPackageInRange(r.Context(), pkg, lastWeek, now)
 	if err != nil {


### PR DESCRIPTION
This also bumps to chatjs v3 and luxon date adapter.

Also includes better tooltips on hover.